### PR TITLE
Buttons in the course/exercise tab are disabled during http queries

### DIFF
--- a/tmcrstudioaddin/DESCRIPTION
+++ b/tmcrstudioaddin/DESCRIPTION
@@ -16,7 +16,8 @@ Imports:
   rjson,
   httr,
   tmcRtestrunner,
-  jsonlite
+  jsonlite,
+  shinyjs
 Depends:
   testthat,
   httptest
@@ -25,6 +26,7 @@ Collate:
   'AddinCourseTab.R'
   'AddinLoginTab.R'
   'AddinSubmitTab.R'
+  'Element_Toggles.R'
   'HTTPQueries.R'
   'TestResultsStats.R'
   'TMC_plugin.R'

--- a/tmcrstudioaddin/R/AddinCourseTab.R
+++ b/tmcrstudioaddin/R/AddinCourseTab.R
@@ -26,8 +26,10 @@
 
 .courseTab <- function(input, output, session) {
   observeEvent(input$refreshOrganizations, {
+    tmcrstudioaddin::disable_course_tab()
     choices <- tmcrstudioaddin::getAllOrganizations()
     shiny::updateSelectInput(session, "organizationSelect", label = "Select organization", choices = choices, selected = 1)
+    tmcrstudioaddin::enable_course_tab()
   })
 
   observeEvent(input$organizationSelect, {
@@ -41,6 +43,7 @@
   exercise_map <<- list()
 
   observeEvent(input$courseSelect, {
+    tmcrstudioaddin::disable_course_tab()
     exercises <- tmcrstudioaddin::getAllExercises(input$courseSelect)
     choices <- exercises$id
     names(choices)<-exercises$name
@@ -48,38 +51,50 @@
     exercise_map <<- exercises$id
     names(exercise_map) <<- exercises$name
     shiny::updateCheckboxGroupInput(session, "exercises", label = "Downloadable exercises", choices = choices)
+    tmcrstudioaddin::enable_course_tab()
   }, ignoreInit=TRUE)
 
   observeEvent(input$refreshCourses, {
+    tmcrstudioaddin::disable_course_tab()
     organization <- input$organizationSelect
     courses <- tmcrstudioaddin::getAllCourses(organization)
     choices <- courses$id
     names(choices) <- courses$name
+
     if (length(choices) == 0){
       credentials <- tmcrstudioaddin::getCredentials()
       if (is.null(credentials$token)){
         rstudioapi::showDialog("Not logged in", "Please log in to see courses", "")
       }
     }
+
     shiny::updateSelectInput(session, "courseSelect", label = "Select course", choices = choices, selected = 1)
+    tmcrstudioaddin::enable_course_tab()
   }, ignoreInit = TRUE)
 
   observeEvent(input$download, {
+    tmcrstudioaddin::disable_course_tab()
+
     tryCatch({
       organization <- input$organizationSelect
       courses <- tmcrstudioaddin::getAllCourses(organization)
       courseName <- courses$name[courses$id==input$courseSelect]
+
       if(!dir.exists(courseName)){
         dir.create(courseName)
       }
+
       for(exercise in input$exercises){
         name <- returnItem(exercise, exercise_map)
         tmcrstudioaddin::download_exercise(exercise,zip_name=paste(exercise,".zip"), exercise_directory = courseName, exercise_name = name)
       }
+
       rstudioapi::showDialog("Success","Exercises downloaded succesfully","")
     }, error = function(e){
       rstudioapi::showDialog("Error","Something went wrong","")
     })
+
+    tmcrstudioaddin::enable_course_tab()
   })
 }
 

--- a/tmcrstudioaddin/R/AddinLoginTab.R
+++ b/tmcrstudioaddin/R/AddinLoginTab.R
@@ -40,6 +40,7 @@
       .logoutPane(ns)
     }})
   observeEvent(input$login, {
+    tmcrstudioaddin::disable_elements("login")
     # Authenticate with the values from the username and password input fields
     response <- tmcrstudioaddin::authenticate(input$username, input$password, input$serverAddress)
     titleAndMessage <- .getTitleAndMessage(response = response)
@@ -47,13 +48,17 @@
     rstudioapi::showDialog(title = titleAndMessage$title,
                            message = titleAndMessage$message,
                            url = "")
+
     # If user has saved credentials update view
     credentials <- tmcrstudioaddin::getCredentials()
+
     if (!is.null(credentials$token)){
       output$loginPane <- renderUI({
         .logoutPane(ns)
       })
     }
+
+    tmcrstudioaddin::enable_elements("login")
   })
   observeEvent(input$logout, {
     #overwrite credentials, so that they contain only the last login address

--- a/tmcrstudioaddin/R/AddinSubmitTab.R
+++ b/tmcrstudioaddin/R/AddinSubmitTab.R
@@ -19,15 +19,18 @@
 
   # This function is run when the Run tests -button is pressed
   runTestrunner <- observeEvent(input$runTests, {
+    tmcrstudioaddin::disable_submit_tab()
     withProgress(message= 'Running tests', value = 1, {
       runResults <- tmcRtestrunner::run_tests(print = TRUE)
     })
     reactive$testResults <- runResults$test_results
     reactive$runStatus <- runResults$run_status
     reactive$submitResults <- NULL
+    tmcrstudioaddin::enable_submit_tab()
   })
 
   submitExercise <- observeEvent(input$submit, {
+    tmcrstudioaddin::disable_submit_tab()
     output <- list()
     withProgress(message= 'Submitting exercise', value = 0, {
       output <- submitCurrent()
@@ -37,6 +40,7 @@
     reactive$testResults <- submitRes$tests
     reactive$runStatus <- "success"
     showMessage(submitRes)
+    tmcrstudioaddin::enable_submit_tab()
   })
 
   showResults <- observeEvent(input$showAllResults, {

--- a/tmcrstudioaddin/R/Element_Toggles.R
+++ b/tmcrstudioaddin/R/Element_Toggles.R
@@ -1,0 +1,29 @@
+disable_elements <- function(...) {
+  elements <- as.list(substitute(list(...)))[-1L]
+
+  lapply(elements, function(i) {shinyjs::disable(i)})
+}
+
+enable_elements <- function(...) {
+  elements <- as.list(substitute(list(...)))[-1L]
+
+  lapply(elements, function(i) {shinyjs::enable(i)})
+}
+
+disable_submit_tab <- function() {
+  disable_elements("runTests", "submit", "showAllResults")
+}
+
+enable_submit_tab <- function() {
+  enable_elements("runTests", "submit", "showAllResults")
+}
+
+disable_course_tab <- function() {
+  disable_elements("refreshOrganizations", "organizationSelect", "refreshCourses",
+                   "courseSelect", "download", "exercises")
+}
+
+enable_course_tab <- function() {
+  enable_elements("refreshOrganizations", "organizationSelect", "refreshCourses",
+                   "courseSelect", "download", "exercises")
+}

--- a/tmcrstudioaddin/R/TMC_plugin.R
+++ b/tmcrstudioaddin/R/TMC_plugin.R
@@ -3,6 +3,7 @@
 
 tmcGadget <- function() {
   ui <- miniPage(
+    shinyjs::useShinyjs(),
     gadgetTitleBar(title = "TMC RStudio", right = NULL,
                    left = miniTitleBarCancelButton(inputId = "exit", label = "Exit")),
 


### PR DESCRIPTION
Buttons are now disabled during HTTP queries and running of tests.
Because the tabs are divided into Shiny modules which have their own namespaces, only the buttons in a single tab can be disabled at a time.