### PR TITLE
Buttons are disabled during longer operations

### DIFF
--- a/tmcrstudioaddin/DESCRIPTION
+++ b/tmcrstudioaddin/DESCRIPTION
@@ -29,6 +29,7 @@ Collate:
   'Exercises.R'
   'ExerciseDataHandler.R'
   'HTTPQueries.R'
+  'InputToggle.R'
   'PropertiesHandler.R'
   'TestResultsStats.R'
   'TMC_plugin.R'

--- a/tmcrstudioaddin/R/AddinCourseTab.R
+++ b/tmcrstudioaddin/R/AddinCourseTab.R
@@ -33,13 +33,21 @@
 
 .courseTab <- function(input, output, session) {
   observeEvent(input$refreshOrganizations, {
+    if(UI_disabled) return()
+
+    tmcrstudioaddin::disable_course_tab()
     organizations <- tmcrstudioaddin::getAllOrganizations()
     choices <- organizations$slug
     names(choices) <- organizations$name
-    shiny::updateSelectInput(session, "organizationSelect", label = "Select organization", choices = choices, selected = 1)
+    shiny::updateSelectInput(session, "organizationSelect", label = "Select organization",
+                             choices = choices, selected = 1)
+    tmcrstudioaddin::enable_course_tab()
   })
 
   observeEvent(input$organizationSelect, {
+    if(UI_disabled) return()
+
+    tmcrstudioaddin::disable_course_tab()
     organization <- input$organizationSelect
     credentials <- tmcrstudioaddin::getCredentials()
     credentials$organization <- organization
@@ -48,11 +56,15 @@
     choices <- courses$id
     names(choices) <- courses$name
     shiny::updateSelectInput(session, "courseSelect", label = "Select course", choices = choices, selected = 1)
+    tmcrstudioaddin::enable_course_tab()
   })
 
   exercise_map <<- list()
 
   observeEvent(input$courseSelect, {
+    if(UI_disabled) return()
+
+    tmcrstudioaddin::disable_course_tab()
     hide("all_exercises")
     shiny::updateCheckboxGroupInput(session, "exercises", label = "", choices = list())
     withProgress(message = "Fetching exercises", {
@@ -65,23 +77,34 @@
       show("all_exercises")
       shiny::updateCheckboxGroupInput(session, "exercises", label = "Downloadable exercises", choices = exercise_map)
     }
+
+    tmcrstudioaddin::enable_course_tab()
   }, ignoreInit=TRUE)
 
   observeEvent(input$refreshCourses, {
+    if(UI_disabled) return()
+
+    tmcrstudioaddin::disable_course_tab()
     organization <- input$organizationSelect
     courses <- tmcrstudioaddin::getAllCourses(organization)
     choices <- courses$id
     names(choices) <- courses$name
+
     if (length(choices) == 0){
       credentials <- tmcrstudioaddin::getCredentials()
+
       if (is.null(credentials$token)){
         rstudioapi::showDialog("Not logged in", "Please log in to see courses", "")
       }
     }
+
     shiny::updateSelectInput(session, "courseSelect", label = "Select course", choices = choices, selected = 1)
+    tmcrstudioaddin::enable_course_tab()
   }, ignoreInit = TRUE)
+
   observeEvent(input$all_exercises, {
     disable("all_exercises")
+
     if(input$all_exercises){
       shiny::updateCheckboxGroupInput(session,"exercises",choices = exercise_map,selected = exercise_map)
     }
@@ -90,7 +113,12 @@
     }
     enable("all_exercises")
   })
+
   observeEvent(input$download, {
+    if(UI_disabled) return()
+
+    tmcrstudioaddin::disable_course_tab()
+
     tryCatch({
       withProgress(message="Downloading exercises",{
 
@@ -121,6 +149,8 @@
     }, error = function(e){
       rstudioapi::showDialog("Error","Something went wrong","")
     })
+
+    tmcrstudioaddin::enable_course_tab()
   })
 }
 

--- a/tmcrstudioaddin/R/AddinLoginTab.R
+++ b/tmcrstudioaddin/R/AddinLoginTab.R
@@ -21,7 +21,7 @@
     div(style = "position:relative;", actionButton(inputId = ns("login"), label = "Log in")),
     div(style = "margin-top:30px;", textInput(inputId = ns("serverAddress"), label = "Server address", value =
                 ifelse(!is.null(serverAddress), serverAddress, ""))),
-    div(style = "position:relative", checkboxInput(inputId = ns("changeServer"), label = "Change server address", value = FALSE), 
+    div(style = "position:relative", checkboxInput(inputId = ns("changeServer"), label = "Change server address", value = FALSE),
       actionButton(inputId = ns("resetServer"), label = "Reset server address"))
   ))
 }
@@ -45,8 +45,12 @@
       .logoutPane(ns)
     }
   })
-  
+
   observeEvent(input$login, {
+    if(UI_disabled) return()
+
+    tmcrstudioaddin::disable_login_tab()
+
     # Authenticate with the values from the username and password input fields
     response <- tmcrstudioaddin::authenticate(input$username, input$password, input$serverAddress)
     titleAndMessage <- .getTitleAndMessage(response = response)
@@ -56,26 +60,34 @@
                            url = "")
     # If user has saved credentials update view
     credentials <- tmcrstudioaddin::getCredentials()
+
     if (!is.null(credentials$token)){
       output$loginPane <- renderUI({
         .logoutPane(ns)
       })
     }
+
+    tmcrstudioaddin::enable_login_tab()
   })
-  
+
   observeEvent(input$logout, {
+    if(UI_disabled) return()
+
     #overwrite credentials, so that they contain only the last login address
     tryCatch({
       credentials <- tmcrstudioaddin::getCredentials()
       credentials <- list(serverAddress=credentials$serverAddress)
       tmcrstudioaddin::saveCredentials(credentials)
     })
+
     output$loginPane <- renderUI({
       .loginPane(ns)
     })
   })
 
   observeEvent(input$resetServer, {
+    if(UI_disabled) return()
+
     updateTextInput(session, "serverAddress", value = "https://tmc.mooc.fi")
     disable("serverAddress")
     updateCheckboxInput(session, "changeServer", value = FALSE)
@@ -91,7 +103,7 @@
 .suggestServer <- function() {
   tryCatch({
     credentials <- tmcrstudioaddin::getCredentials()
-    
+
     if (is.null(credentials$serverAddress)) {
       defaultServerAddress <- "https://tmc.mooc.fi"
 

--- a/tmcrstudioaddin/R/AddinSubmitTab.R
+++ b/tmcrstudioaddin/R/AddinSubmitTab.R
@@ -26,6 +26,9 @@
 
   # This function is run when the Run tests -button is pressed
   runTestrunner <- observeEvent(input$runTests, {
+    if(UI_disabled) return()
+
+    tmcrstudioaddin::disable_submit_tab()
     runResults <- withProgress(message= 'Running tests', value = 1, {
       tryCatch({
         #error("lel")
@@ -42,9 +45,13 @@
     reactive$runStatus <- runResults$run_status
     reactive$submitResults <- NULL
     reactive$sourcing <- FALSE
+    tmcrstudioaddin::enable_submit_tab()
   })
 
   submitExercise <- observeEvent(input$submit, {
+    if(UI_disabled) return()
+
+    tmcrstudioaddin::disable_submit_tab()
     output <- list()
     withProgress(message= 'Submitting exercise', value = 0, {
       output <- submitCurrent()
@@ -55,23 +62,34 @@
     reactive$runStatus <- "success"
     showMessage(submitRes)
     reactive$sourcing <- FALSE
+    tmcrstudioaddin::enable_submit_tab()
   })
 
   showResults <- observeEvent(input$showAllResults, {
+    if(UI_disabled) return()
+
     reactive$showAll = input$showAllResults
   })
 
   selectedExercises <- observeEvent(input$selectExercise, {
+    if(UI_disabled) return()
+
     selectedExercise <<- input$selectExercise
   })
 
   sourceExercise <- observeEvent(input$source, {
+    if(UI_disabled) return()
+
+    tmcrstudioaddin::disable_submit_tab()
+
     tryCatch({
       sourceExercise(selectedExercise)
       reactive$sourcing <- TRUE
     }, error = function(e) {
       rstudioapi::showDialog("Sourcing failed", "Error while sourcing exercise.")
     })
+
+    tmcrstudioaddin::enable_submit_tab()
   })
 
   # Renders a list showing the test results

--- a/tmcrstudioaddin/R/InputToggle.R
+++ b/tmcrstudioaddin/R/InputToggle.R
@@ -1,0 +1,41 @@
+assign(x = "UI_disabled", value = FALSE, envir = .GlobalEnv)
+
+disable_elements <- function(...) {
+  elements <- as.list(substitute(list(...)))[-1L]
+  lapply(elements, function(i) {shinyjs::disable(i)})
+  UI_disabled <<- TRUE
+}
+
+enable_elements <- function(...) {
+  elements <- as.list(substitute(list(...)))[-1L]
+  lapply(elements, function(i) {shinyjs::enable(i)})
+  shinyjs::delay(ms = 1000, expr = UI_disabled <<- FALSE)
+}
+
+disable_submit_tab <- function() {
+  disable_elements("selectExercise", "source", "runTests", "submit", "showAllResults")
+}
+
+enable_submit_tab <- function() {
+  enable_elements("selectExercise", "source", "runTests", "submit", "showAllResults")
+}
+
+disable_course_tab <- function() {
+  disable_elements("refreshOrganizations", "organizationSelect", "refreshCourses",
+                   "courseSelect", "download", "all_exercises", "exercises")
+}
+
+enable_course_tab <- function() {
+  enable_elements("refreshOrganizations", "organizationSelect", "refreshCourses",
+                  "courseSelect", "download", "all_exercises", "exercises")
+}
+
+disable_login_tab <- function() {
+  disable_elements("username", "password", "login", "changeServer", "resetServer", "logout")
+}
+
+enable_login_tab <- function() {
+  enable_elements("username", "password", "login", "changeServer","resetServer",  "logout")
+}
+
+

--- a/tmcrstudioaddin/R/TMC_plugin.R
+++ b/tmcrstudioaddin/R/TMC_plugin.R
@@ -18,6 +18,8 @@ tmcGadget <- function() {
   server <- function(input, output, session) {
     # Function for the exit button
     observeEvent(input$exit, {
+      if(UI_disabled) return()
+
       return(shiny::stopApp())
     })
 


### PR DESCRIPTION
Buttons are disabled (or set to ignore clicks if they are in a different tab than the original pressed button) during longer operations to prevent excessive buffering of unwanted button operations. 