### PR TITLE
Fix: PropertiesHandler's tests don't affect properties file.

### DIFF
--- a/tmcrstudioaddin/tests/testthat/helperPropertiesHandler.R
+++ b/tmcrstudioaddin/tests/testthat/helperPropertiesHandler.R
@@ -1,0 +1,19 @@
+user_home <- Sys.getenv("HOME")
+properties_file <- file.path(user_home, "tmcr", ".properties.rds")
+properties_file_backup <- file.path(user_home, "tmcr", ".properties.rds.backup")
+
+# Backups properties file if it exists
+backup_properties_file <- function() {
+  if (file.exists(properties_file)) {
+    file.copy(properties_file, properties_file_backup, overwrite = TRUE)
+    file.remove(properties_file)
+  }
+}
+
+# Restores properties file backup if it exists
+restore_properties_file_backup <- function() {
+  if (file.exists(properties_file_backup)) {
+    file.copy(properties_file_backup, properties_file, overwrite = TRUE)
+    file.remove(properties_file_backup)
+  }
+}

--- a/tmcrstudioaddin/tests/testthat/testPropertiesHandler.R
+++ b/tmcrstudioaddin/tests/testthat/testPropertiesHandler.R
@@ -1,28 +1,44 @@
 test_that("Properties created", {
+  backup_properties_file()
+
   create_properties_file()
   expect_true(check_if_properties_exist())
+
+  restore_properties_file_backup()
 })
 
 test_that("TMC's home directory is correct", {
+  backup_properties_file()
+
   user_home <- Sys.getenv("HOME")
   tmcr_directory <- file.path(user_home, "tmcr")
 
   expect_equal(tmcr_directory,
       get_tmcr_directory())
+
+  restore_properties_file_backup()
 })
 
 test_that("Properties are read as expected", {
+  backup_properties_file()
+
   create_properties_file()
   properties <- read_properties()
 
   expect_equal(properties$`tmcr-dir`,
       paste(tmcrstudioaddin::get_tmcr_directory(), "tmcr-projects",
             sep = .Platform$file.sep))
+
+  restore_properties_file_backup()
 })
 
 test_that("get_projects_folder-function works as expected", {
+  backup_properties_file()
+
   create_properties_file(tmcr_projects = "tmcproj")
   tmcr_path <- get_tmcr_directory()
   project_path <- paste(tmcr_path, "tmcproj", sep = .Platform$file.sep)
   expect_equal(get_projects_folder(), project_path)
+
+  restore_properties_file_backup()
 })


### PR DESCRIPTION
Suggestion on how to handle PropertiesHandler.R testing without affecting properties file.